### PR TITLE
Added transition delete functionality to delete tool

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -276,6 +276,13 @@ const Editor = () => {
     }
   }
 
+  // Handle Deleting a transition
+  function handleTransitionDelete(tr) {
+    nodeList[tr.from].transitions = nodeList[tr.from].transitions.filter((transition) => transition.id != tr.id);
+    nodeList[tr.to].transitions = nodeList[tr.to].transitions.filter((transition) => transition.id != tr.id);
+    updateTransitions(transitions.filter((transition) => transition.id != tr.id));
+  }
+
   // Generate Points for drawing transition arrow
   function getPoints(id1, id2) {
     if (id1 == id2) {
@@ -453,7 +460,7 @@ const Editor = () => {
             {transitions.map(
               (transition) =>
                 transition && (
-                  <Group key={transition.id}>
+                  <Group key={transition.id} onClick={() => (currentEditorState == "delete") && handleTransitionDelete(transition)}>
                     {/* Transition arrow object */}
                     <Arrow
                       key={transition.id}

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -36,8 +36,8 @@ const TutorialContent = [
   {
     title: "Delete",
     src: "https://www.youtube.com/embed/VNAN27cCGUY?si=DnGpzma27Ehb5sft",
-    content: `Delete, as the name suggests lets you remove states from your project.
-    Choose "Delete" and left-click on the State you wish to remove.`,
+    content: `Delete, as the name suggests lets you remove states or transitions from your project.
+    Choose "Delete" and left-click on the State or transition you wish to remove.`,
     type: "vid",
   },
 


### PR DESCRIPTION
Addresses #13 
This functionality is added directly to the delete tool. This implementation works fine, but the clickable area to delete a transition is only the text and the arrow head, maybe something to fix in the future. Also modified welcome tutorial to reflect the change.