### PR TITLE
Deselects selected node when editor is clicked

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -83,8 +83,19 @@ const Editor = () => {
 
   // Handle Creating Nodes by clicking
   function handleEditorClick(e: any) {
-    // Return if not in create mode
-    if (currentEditorState != "create") return;
+    // Return if not in create mode, and deselects if a node is selected
+    if (currentEditorState != "create") {
+      if (currSelected != "nil") {
+        const selectedNode = layerRef.current.findOne(`#${currSelected}`);
+        selectedNode.to({
+          duration: 0.1,
+          strokeWidth: 0,
+          easing: Konva.Easings.EaseInOut,
+        });
+        setCurrSelected("nil");
+      }
+      return;
+    }
 
     const group = e.target.getStage().findOne("Group");
     if (!group) return;


### PR DESCRIPTION
If a node is selected and the user clicks on the editor background it will deselect the node. This just feels more natural in my opinion.