### PR TITLE
Delete transition in delete tool

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -276,6 +276,13 @@ const Editor = () => {
     }
   }
 
+  // Handle Deleting a transition
+  function handleTransitionDelete(tr) {
+    nodeList[tr.from].transitions = nodeList[tr.from].transitions.filter((transition) => transition.id != tr.id);
+    nodeList[tr.to].transitions = nodeList[tr.to].transitions.filter((transition) => transition.id != tr.id);
+    updateTransitions(transitions.filter((transition) => transition.id != tr.id));
+  }
+
   // Generate Points for drawing transition arrow
   function getPoints(id1, id2) {
     if (id1 == id2) {
@@ -453,7 +460,7 @@ const Editor = () => {
             {transitions.map(
               (transition) =>
                 transition && (
-                  <Group key={transition.id}>
+                  <Group key={transition.id} onClick={() => (currentEditorState == "delete") && handleTransitionDelete(transition)}>
                     {/* Transition arrow object */}
                     <Arrow
                       key={transition.id}

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -278,9 +278,19 @@ const Editor = () => {
 
   // Handle Deleting a transition
   function handleTransitionDelete(tr) {
-    nodeList[tr.from].transitions = nodeList[tr.from].transitions.filter((transition) => transition.id != tr.id);
-    nodeList[tr.to].transitions = nodeList[tr.to].transitions.filter((transition) => transition.id != tr.id);
-    updateTransitions(transitions.filter((transition) => transition.id != tr.id));
+    // Removing transition from states related to the transition
+    nodeList[tr.from].transitions = nodeList[tr.from].transitions.filter((transition) => transition.trId != tr.id);
+    nodeList[tr.to].transitions = nodeList[tr.to].transitions.filter((transition) => transition.trId != tr.id);
+
+    // Yoinked code from node delete
+    const tre = layerRef.current.findOne(`#tr${tr.id}`);
+    tre.destroy(); // Delete the arrow
+
+    const trText = layerRef.current.findOne(`#trtext${tr.id}`);
+    trText.destroy(); // Also delete the Label of the transition
+
+    transitions[tr.id] = undefined; // remove arrow entry from array
+    updateTransitions(transitions);
   }
 
   // Generate Points for drawing transition arrow

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -36,8 +36,8 @@ const TutorialContent = [
   {
     title: "Delete",
     src: "https://www.youtube.com/embed/VNAN27cCGUY?si=DnGpzma27Ehb5sft",
-    content: `Delete, as the name suggests lets you remove states from your project.
-    Choose "Delete" and left-click on the State you wish to remove.`,
+    content: `Delete, as the name suggests lets you remove states or transitions from your project.
+    Choose "Delete" and left-click on the State or transition you wish to remove.`,
     type: "vid",
   },
 


### PR DESCRIPTION
#21 but it actually works
Addresses #13 
This functionality is added directly to the delete tool. This implementation works fine, but the clickable area to delete a transition is only the text and the arrow head, maybe something to fix in the future. Also modified welcome tutorial to reflect the change.