### PR TITLE
Fix: Cached the contributors to eliminate unnecessary fetches

### DIFF
--- a/src/components/Guide.jsx
+++ b/src/components/Guide.jsx
@@ -1,8 +1,7 @@
-import { editor_state } from "../lib/stores";
+import { editor_state, contributors_list } from "../lib/stores";
 import { useAtom } from "jotai";
 import { ArrowRight, ArrowLeft, Target, ExternalLink } from "lucide-react";
-import { useEffect } from "react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 const Guide = () => {
   // Jotai Stores
@@ -145,10 +144,11 @@ function Page3() {
 }
 
 function Page4() {
-  const [contributors, setContributors] = useState(null);
+  const [contributors, setContributors] = useAtom(contributors_list);
 
   useEffect(() => {
     async function getContributors() {
+      if (contributors) return;
       let res = await fetch(
         "https://api.github.com/repos/karthik-saiharsh/fsm-engine/contributors"
       );

--- a/src/lib/stores.js
+++ b/src/lib/stores.js
@@ -50,3 +50,6 @@ export const active_transition = atom(null);
 
 // Export store provider
 export const store = createStore();
+
+// Store to hold contributors list
+export const contributors_list = atom(null);


### PR DESCRIPTION
Problem:
The app was pulling the GitHub contributors lst every time you switched views. 

Reason:
The repeatd calls were pointless and slowed things down a bit, plus it used the GitHub API way more than needed.

Proposed Solution:
I added a small cache so it only fetches once and reuses the data after that.

Result:
Cleaner behavior: one fetch up front, everything faster after that.