### PR TITLE
Add mobile detection and warning UI Prevents app break on small screens

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -13,10 +13,21 @@ import TransitionTable from "./components/TransitionTable";
 import ConfirmDialog from "./components/ConfirmDialog";
 import { handleShortCuts } from "./lib/editor";
 import { editor_state } from "./lib/stores";
+import { useState } from "react";
 
 export function App() {
 	// Disable right click context menu
 	// Got this useEffect code from StackOverflow
+	const [isMobile,SetMobile] = useState(false);
+	
+	useEffect(()=>{
+		const Device = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+		navigator.userAgent
+		);	
+
+		SetMobile(Device);
+	},[]);
+
 	useEffect(() => {
 		const handleContextmenu = (e) => {
 			e.preventDefault();
@@ -41,6 +52,18 @@ export function App() {
 	}, [handleKeyPress]);
 
 	const EditorState = useAtomValue(editor_state);
+
+	if (isMobile){
+		return(
+			<div className="h-screen w-screen flex items-center justify-center bg-gradient-to-br from-gray-900 via-gray-800 to-gray-700 text-gray-200 p-6 text-center">
+				<p className="text-2xl font-semibold tracking-wide text-gray-100 drop-shadow-[0_0_7px_rgba(255,255,255,0.7)]">
+					FSM Engine is Designed for Desktop/Laptop use only..!
+					<br/>
+					Please open this application on a bigger device
+				</p>
+			</div>
+		)
+	}
 
 	return (
 		<div id="body" className="w-screen h-screen bg-primary-bg overflow-hidden">


### PR DESCRIPTION
### Summary
Implemented mobile device detection logic and added a gradient warning screen UI.
This prevents the core FSM Engine UI from rendering on mobile devices, avoiding layout
breakage and letting users know the application is intended for desktop/laptop only.

### Changes
- Added useState + userAgent detection for mobile browser identification
- Added conditional early-return for mobile devices
- Created a gradient background warning screen with glowing text styling

### Testing
- Verified on desktop and resized browser window (no warning appears)
- Verified on real mobile device using `npm run dev -- --host` (warning displays correctly)

