### PR TITLE
feat(ui): Added a custom alert window

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,12 +10,12 @@
     "check": "svelte-check --tsconfig ./tsconfig.app.json && tsc -p tsconfig.node.json"
   },
   "devDependencies": {
-    "@internationalized/date": "^3.10.0",
+    "@internationalized/date": "^3.12.0",
     "@sveltejs/vite-plugin-svelte": "^6.2.1",
     "@tsconfig/svelte": "^5.0.6",
     "@types/dagre": "^0.7.54",
     "@types/node": "^24.10.1",
-    "bits-ui": "^2.14.4",
+    "bits-ui": "^2.16.3",
     "svelte": "^5.43.8",
     "svelte-check": "^4.3.4",
     "typescript": "~5.9.3",
@@ -27,7 +27,7 @@
   "dependencies": {
     "@dagrejs/dagre": "^3.0.0",
     "@fsm/engine": "workspace:*",
-    "@lucide/svelte": "^0.561.0",
+    "@lucide/svelte": "0.561.0",
     "@tailwindcss/vite": "^4.1.18",
     "clsx": "^2.1.1",
     "konva": "^10.2.0",

--- a/apps/web/src/lib/brain/extras.svelte.ts
+++ b/apps/web/src/lib/brain/extras.svelte.ts
@@ -8,6 +8,27 @@
  * @fileoverview This class contains global stores that aren't
  * as important and so needn't belong in ProjectClass */
 
+
+/**
+ * Describes the parameters of the alert window popup
+ */
+export interface AlertParams {
+    /** Should the Window be visible */
+    visible: boolean,
+    /** What kind of a window is it ? Info only shows info
+     * confirm has a yes/no button that the user has to acknowledge
+     */
+    type: "info" | "confirm",
+    /** What message should be displayed */
+    message: string | null,
+
+    /** If type is confirm, what has to be done on accept */
+    onAccept: null | (() => void),
+
+    /** What to do on cancel if type is confirm*/
+    onReject: null | (() => void),
+};
+
 class SecondaryStores {
     // should grid be shown ?
     grid_shown = $state<boolean>(true);
@@ -32,6 +53,42 @@ class SecondaryStores {
 
     // Language Specific Settings Window
     show_lang_settings = $state(false);
+
+    // Custom Alert Window
+    alert_popup: AlertParams = $state({
+        visible: false,
+        type: "info",
+        message: null,
+        onAccept: null,
+        onReject: null,
+    });
+
+    /**
+     * Opens a new Alert Window
+     * @param alert_params parameters of the alert window. see @interface AlertParams
+     */
+    openAlert(type: "info" | "confirm", message: string, onAccept?: () => void, onReject?: () => void) {
+
+        // Define a fallback default onRejectFunction that simple closes the alert again
+        const defaultClose = () => {
+            this.alert_popup = { ...this.alert_popup, visible: false };
+        }
+
+
+        if (type === "info") {
+            this.alert_popup = { visible: true, type, message, onAccept: null, onReject: defaultClose };
+        } else {
+
+            this.alert_popup = {
+                visible: true,
+                type,
+                message,
+                onAccept: onAccept ? () => { defaultClose(); onAccept() } : defaultClose, // After the onAccept function runs, the alert must close again, hence defaultClose is called before onAccept to close the alert popup
+                onReject: onReject ?? defaultClose
+            }
+        }
+    }
+
 }
 
 const secondary_stores = new SecondaryStores();

--- a/apps/web/src/lib/brain/store.svelte.ts
+++ b/apps/web/src/lib/brain/store.svelte.ts
@@ -203,7 +203,7 @@ class Project {
                     document.getElementById("body")?.classList.toggle("dark", this.theme === "dark");
                 } catch (error) {
                     console.error("Failed to parse project file", error);
-                    alert("Invalid project file.");
+                    secondary_stores.openAlert("info", "Invalid project file.");
                 }
             };
             reader.readAsText(file);
@@ -289,7 +289,7 @@ class Project {
                     if (result.success) {
                         tr_id = result.tr_id!;
                     } else {
-                        alert(result.error);
+                        secondary_stores.openAlert("info", result.error ?? "");
                         secondary_stores.from_node = null;
                         return;
                     }
@@ -504,8 +504,10 @@ class Project {
         this.engine.setNodes(this.nodes);
         this.engine.setTransitions(this.transitions);
 
-        // Open Machine Settings Window
-        secondary_stores.show_lang_settings = true;
+        // Open Machine Settings Window if not in FREE mode
+        if (projType !== EngineTypes.FREE) {
+            secondary_stores.show_lang_settings = true;
+        }
     }
 
 

--- a/apps/web/src/lib/components/Dock.svelte
+++ b/apps/web/src/lib/components/Dock.svelte
@@ -13,6 +13,9 @@
     import ProjectClass from "../brain/store.svelte";
     import type { Component } from "svelte";
     import type { IconProps } from "@lucide/svelte";
+    import AdditionalTools from "./editor/AdditionalTools.svelte";
+    import Separator from "./ui/separator/separator.svelte";
+    import { DFA, EngineTypes } from "@fsm/engine";
 
     // Get props from Editor
     let { stage } = $props();
@@ -107,5 +110,10 @@
                 <DockItem.icon />
             </Button>
         {/each}
+
+        {#if ProjectClass.project_details.type !== EngineTypes.FREE}
+            <span class="h-10 w-px bg-primary/20"> </span>
+            <AdditionalTools />
+        {/if}
     </div>
 </main>

--- a/apps/web/src/lib/components/Editor.svelte
+++ b/apps/web/src/lib/components/Editor.svelte
@@ -35,6 +35,8 @@
     import LangSettings from "./popus/LangSettings.svelte";
     import { render } from "svelte/server";
     import type { LabelDraw, TransitionDraw } from "../brain/types";
+    import Alert from "./Alert.svelte";
+    import CustomAlert from "./popus/CustomAlert.svelte";
 
     const defaultLook = ProjectClass.defaultNodeLook;
     const Nodes = ProjectClass.nodes;
@@ -386,6 +388,7 @@
 <TransitionCustomizer />
 <TransitionTable />
 <LangSettings />
+<CustomAlert />
 <!-- Additional Overlays and Popup Windows -->
 
 <!-- Options Dock -->

--- a/apps/web/src/lib/components/editor/AdditionalTools.svelte
+++ b/apps/web/src/lib/components/editor/AdditionalTools.svelte
@@ -1,0 +1,36 @@
+<!--
+    /* Copyright (C) 2026 Illindala Karthik Saiharsh - All Rights Reserved
+     * You may use, distribute and modify this code under the
+     * terms of the GPL V3 license.
+     * I would prefer it if you provide credits, in case you use my code for your projects :)
+     */ 
+-->
+
+<script lang="ts">
+    import * as DropdownMenu from "../ui/dropdown-menu/index";
+    import Button from "../ui/button/button.svelte";
+    import secondary_stores from "../../brain/extras.svelte";
+    // import DropdownMenu from "../ui/dropdown-menu/dropdown-menu.svelte";
+</script>
+
+<DropdownMenu.Root>
+    <DropdownMenu.Trigger>
+        <Button variant="outline">Additional Functions</Button>
+    </DropdownMenu.Trigger>
+
+    <DropdownMenu.Content class="w-fit" align="start">
+        <DropdownMenu.Group>
+            <DropdownMenu.Item
+                class="px-4 py-2 my-0.5"
+                onclick={() =>
+                    secondary_stores.openAlert("info", "Feature Coming Soon!")}
+                >Validate a String</DropdownMenu.Item>
+
+            <DropdownMenu.Item
+                class="px-4 py-2 my-0.5"
+                onclick={() =>
+                    secondary_stores.openAlert("info", "Feature Coming Soon!")}
+                >DFA from Regular Expression</DropdownMenu.Item>
+        </DropdownMenu.Group>
+    </DropdownMenu.Content>
+</DropdownMenu.Root>

--- a/apps/web/src/lib/components/editor/MachinePicker.svelte
+++ b/apps/web/src/lib/components/editor/MachinePicker.svelte
@@ -8,6 +8,7 @@
     import { cn } from "../../utils";
     import ProjectClass from "../../brain/store.svelte";
     import { EngineTypes } from "@fsm/engine";
+    import secondary_stores from "../../brain/extras.svelte";
 
     const frameworks: { value: string; label: string; typ?: EngineTypes }[] = [
         {
@@ -66,8 +67,9 @@
 
         // Alert if un available state chosen
         if (index > 1) {
-            alert(
-                "Only DFA mode is available for now. I are working on implementing the other machines as well. Hang on, give me some time."
+            secondary_stores.openAlert(
+                "info",
+                "Only DFA mode is available for now. I am working on implementing the other machines as well. Hang on, give me some time."
             );
             return;
         }

--- a/apps/web/src/lib/components/editor/TopBar.svelte
+++ b/apps/web/src/lib/components/editor/TopBar.svelte
@@ -67,7 +67,16 @@
     <!-- Project Meta Data Settings and Details -->
 
     <!-- New Project  -->
-    <Button variant="outline" onclick={() => ProjectClass.newProject()}>
+    <Button
+        variant="outline"
+        onclick={() =>
+            secondary_stores.openAlert(
+                "confirm",
+                "Are you sure you want to create a new Project ? Creating a new project will start a blank canvas. Any unsaved work will be lost. Please save any unsaved work if needed.",
+                () => {
+                    ProjectClass.newProject();
+                }
+            )}>
         <CirclePlus />
         <p class="font-geist">New</p>
     </Button>

--- a/apps/web/src/lib/components/popus/CustomAlert.svelte
+++ b/apps/web/src/lib/components/popus/CustomAlert.svelte
@@ -1,0 +1,54 @@
+<!--
+    /* Copyright (C) 2026 Illindala Karthik Saiharsh - All Rights Reserved
+     * You may use, distribute and modify this code under the
+     * terms of the GPL V3 license.
+     * I would prefer it if you provide credits, in case you use my code for your projects :)
+     */ 
+-->
+
+<script lang="ts">
+    import ProjectClass from "../../brain/store.svelte";
+    import * as Card from "../ui/card/index";
+    import Button from "../ui/button/button.svelte";
+    import { X, Download, ImageDown } from "@lucide/svelte";
+    import secondary_stores from "../../brain/extras.svelte";
+</script>
+
+{#if secondary_stores.alert_popup.visible}
+    <main
+        class="absolute top-0 left-0 z-20 flex justify-center items-center w-screen h-screen bg-background/10 backdrop-blur">
+        <Card.Root
+            class={`-my-4 w-full max-w-sm shadow-[0px_0px_50px_0px_#000000${ProjectClass.theme === "dark" ? "85" : "25"}]`}>
+            <Card.Header>
+                <Card.Title class="font-geist">Heads up!</Card.Title>
+                <Card.Description class="font-geist"
+                    >Something demands your attention</Card.Description>
+                <Card.Action onclick={secondary_stores.alert_popup.onReject}>
+                    <Button variant="link" size="icon"><X /></Button>
+                </Card.Action>
+            </Card.Header>
+
+            <Card.Content
+                class="flex flex-col justify-center items-center gap-6">
+                <p class="text-sm">
+                    {secondary_stores.alert_popup.message}
+                </p>
+            </Card.Content>
+
+            <Card.Footer class="flex justify-center items-center gap-5">
+                <Button
+                    onclick={secondary_stores.alert_popup.onReject}
+                    variant="secondary"
+                    >{secondary_stores.alert_popup.type === "info"
+                        ? "Close"
+                        : "Cancel"}</Button>
+
+                {#if secondary_stores.alert_popup.type === "confirm"}
+                    <Button
+                        onclick={secondary_stores.alert_popup.onAccept}
+                        variant="default">Okay</Button>
+                {/if}
+            </Card.Footer>
+        </Card.Root>
+    </main>
+{/if}

--- a/apps/web/src/lib/components/popus/LangSettings.svelte
+++ b/apps/web/src/lib/components/popus/LangSettings.svelte
@@ -31,13 +31,16 @@
     function collectLanguageAlphabets() {
         let alphabets = alphabetInput.split(",");
         alphabets = alphabets.map((alph) => alph.trim());
-
-        if (alphabets.length) {
+        console.log(alphabets)
+        if (alphabets.join("").length > 0) {
             if (ProjectClass.engine instanceof DFA) {
                 ProjectClass.engine.addAlphabets(...alphabets);
             }
         } else {
-            alert("You have to enter atleast one alphabet!");
+            secondary_stores.openAlert(
+                "info",
+                "You have to enter atleast one alphabet!"
+            );
         }
 
         handleCancel();

--- a/apps/web/src/lib/components/popus/StringValidator.svelte
+++ b/apps/web/src/lib/components/popus/StringValidator.svelte
@@ -1,0 +1,27 @@
+<!--
+    /* Copyright (C) 2026 Illindala Karthik Saiharsh - All Rights Reserved
+     * You may use, distribute and modify this code under the
+     * terms of the GPL V3 license.
+     * I would prefer it if you provide credits, in case you use my code for your projects :)
+     */ 
+-->
+
+<script lang="ts">
+    import Window from "../generic/Window.svelte";
+    import secondary_stores from "../../brain/extras.svelte";
+
+    /**
+     * Function to handle Closing of the Transition table window
+     */
+    function closeWindow() {
+        secondary_stores.show_transition_table = false;
+    }
+</script>
+
+<Window
+    win_dim={{ width: 500, height: 200 }}
+    title="Transition Table"
+    is_shown={secondary_stores.show_transition_table}
+    {closeWindow}>
+    <div></div>
+</Window>

--- a/apps/web/src/lib/components/ui/dropdown-menu/dropdown-menu-checkbox-group.svelte
+++ b/apps/web/src/lib/components/ui/dropdown-menu/dropdown-menu-checkbox-group.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import { DropdownMenu as DropdownMenuPrimitive } from "bits-ui";
+
+	let {
+		ref = $bindable(null),
+		value = $bindable([]),
+		...restProps
+	}: DropdownMenuPrimitive.CheckboxGroupProps = $props();
+</script>
+
+<DropdownMenuPrimitive.CheckboxGroup
+	bind:ref
+	bind:value
+	data-slot="dropdown-menu-checkbox-group"
+	{...restProps}
+/>

--- a/apps/web/src/lib/components/ui/dropdown-menu/dropdown-menu-checkbox-item.svelte
+++ b/apps/web/src/lib/components/ui/dropdown-menu/dropdown-menu-checkbox-item.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+	import { DropdownMenu as DropdownMenuPrimitive } from "bits-ui";
+	import MinusIcon from '@lucide/svelte/icons/minus';
+	import CheckIcon from '@lucide/svelte/icons/check';
+	import { cn, type WithoutChildrenOrChild } from "$lib/utils.js";
+	import type { Snippet } from "svelte";
+
+	let {
+		ref = $bindable(null),
+		checked = $bindable(false),
+		indeterminate = $bindable(false),
+		class: className,
+		children: childrenProp,
+		...restProps
+	}: WithoutChildrenOrChild<DropdownMenuPrimitive.CheckboxItemProps> & {
+		children?: Snippet;
+	} = $props();
+</script>
+
+<DropdownMenuPrimitive.CheckboxItem
+	bind:ref
+	bind:checked
+	bind:indeterminate
+	data-slot="dropdown-menu-checkbox-item"
+	class={cn(
+		"focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm data-inset:pl-7 [&_svg:not([class*='size-'])]:size-4 relative flex cursor-default items-center outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		className
+	)}
+	{...restProps}
+>
+	{#snippet children({ checked, indeterminate })}
+		<span
+			class="absolute right-2 flex items-center justify-center pointer-events-none"
+			data-slot="dropdown-menu-checkbox-item-indicator"
+		>
+			{#if indeterminate}
+				<MinusIcon  />
+			{:else if checked}
+				<CheckIcon  />
+			{/if}
+		</span>
+		{@render childrenProp?.()}
+	{/snippet}
+</DropdownMenuPrimitive.CheckboxItem>

--- a/apps/web/src/lib/components/ui/dropdown-menu/dropdown-menu-content.svelte
+++ b/apps/web/src/lib/components/ui/dropdown-menu/dropdown-menu-content.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+	import { cn, type WithoutChildrenOrChild } from "$lib/utils.js";
+	import DropdownMenuPortal from "./dropdown-menu-portal.svelte";
+	import { DropdownMenu as DropdownMenuPrimitive } from "bits-ui";
+	import type { ComponentProps } from "svelte";
+
+	let {
+		ref = $bindable(null),
+		sideOffset = 4,
+		align = "start",
+		portalProps,
+		class: className,
+		...restProps
+	}: DropdownMenuPrimitive.ContentProps & {
+		portalProps?: WithoutChildrenOrChild<ComponentProps<typeof DropdownMenuPortal>>;
+	} = $props();
+</script>
+
+<DropdownMenuPortal {...portalProps}>
+	<DropdownMenuPrimitive.Content
+		bind:ref
+		data-slot="dropdown-menu-content"
+		{sideOffset}
+		{align}
+		class={cn(
+			"data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 bg-popover text-popover-foreground min-w-32 rounded-lg p-1 shadow-md ring-1 duration-100 data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 z-50 w-(--bits-dropdown-menu-anchor-width) overflow-x-hidden overflow-y-auto outline-none data-closed:overflow-hidden",
+			className
+		)}
+		{...restProps}
+	/>
+</DropdownMenuPortal>

--- a/apps/web/src/lib/components/ui/dropdown-menu/dropdown-menu-group-heading.svelte
+++ b/apps/web/src/lib/components/ui/dropdown-menu/dropdown-menu-group-heading.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import { DropdownMenu as DropdownMenuPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+	import type { ComponentProps } from "svelte";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		inset,
+		...restProps
+	}: ComponentProps<typeof DropdownMenuPrimitive.GroupHeading> & {
+		inset?: boolean;
+	} = $props();
+</script>
+
+<DropdownMenuPrimitive.GroupHeading
+	bind:ref
+	data-slot="dropdown-menu-group-heading"
+	data-inset={inset}
+	class={cn("px-2 py-1.5 text-sm font-semibold data-[inset]:ps-8", className)}
+	{...restProps}
+/>

--- a/apps/web/src/lib/components/ui/dropdown-menu/dropdown-menu-group.svelte
+++ b/apps/web/src/lib/components/ui/dropdown-menu/dropdown-menu-group.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { DropdownMenu as DropdownMenuPrimitive } from "bits-ui";
+
+	let { ref = $bindable(null), ...restProps }: DropdownMenuPrimitive.GroupProps = $props();
+</script>
+
+<DropdownMenuPrimitive.Group bind:ref data-slot="dropdown-menu-group" {...restProps} />

--- a/apps/web/src/lib/components/ui/dropdown-menu/dropdown-menu-item.svelte
+++ b/apps/web/src/lib/components/ui/dropdown-menu/dropdown-menu-item.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+	import { DropdownMenu as DropdownMenuPrimitive } from "bits-ui";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		inset,
+		variant = "default",
+		...restProps
+	}: DropdownMenuPrimitive.ItemProps & {
+		inset?: boolean;
+		variant?: "default" | "destructive";
+	} = $props();
+</script>
+
+<DropdownMenuPrimitive.Item
+	bind:ref
+	data-slot="dropdown-menu-item"
+	data-inset={inset}
+	data-variant={variant}
+	class={cn(
+		"focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:text-destructive not-data-[variant=destructive]:focus:**:text-accent-foreground gap-1.5 rounded-md px-1.5 py-1 text-sm data-inset:pl-7 [&_svg:not([class*='size-'])]:size-4 group/dropdown-menu-item relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		className
+	)}
+	{...restProps}
+/>

--- a/apps/web/src/lib/components/ui/dropdown-menu/dropdown-menu-label.svelte
+++ b/apps/web/src/lib/components/ui/dropdown-menu/dropdown-menu-label.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		inset,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> & {
+		inset?: boolean;
+	} = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="dropdown-menu-label"
+	data-inset={inset}
+	class={cn("text-muted-foreground px-1.5 py-1 text-xs font-medium data-inset:pl-7 data-[inset]:pl-8", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/apps/web/src/lib/components/ui/dropdown-menu/dropdown-menu-portal.svelte
+++ b/apps/web/src/lib/components/ui/dropdown-menu/dropdown-menu-portal.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { DropdownMenu as DropdownMenuPrimitive } from "bits-ui";
+
+	let { ...restProps }: DropdownMenuPrimitive.PortalProps = $props();
+</script>
+
+<DropdownMenuPrimitive.Portal {...restProps} />

--- a/apps/web/src/lib/components/ui/dropdown-menu/dropdown-menu-radio-group.svelte
+++ b/apps/web/src/lib/components/ui/dropdown-menu/dropdown-menu-radio-group.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import { DropdownMenu as DropdownMenuPrimitive } from "bits-ui";
+
+	let {
+		ref = $bindable(null),
+		value = $bindable(),
+		...restProps
+	}: DropdownMenuPrimitive.RadioGroupProps = $props();
+</script>
+
+<DropdownMenuPrimitive.RadioGroup
+	bind:ref
+	bind:value
+	data-slot="dropdown-menu-radio-group"
+	{...restProps}
+/>

--- a/apps/web/src/lib/components/ui/dropdown-menu/dropdown-menu-radio-item.svelte
+++ b/apps/web/src/lib/components/ui/dropdown-menu/dropdown-menu-radio-item.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+	import { DropdownMenu as DropdownMenuPrimitive } from "bits-ui";
+	import CheckIcon from '@lucide/svelte/icons/check';
+	import { cn, type WithoutChild } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children: childrenProp,
+		...restProps
+	}: WithoutChild<DropdownMenuPrimitive.RadioItemProps> = $props();
+</script>
+
+<DropdownMenuPrimitive.RadioItem
+	bind:ref
+	data-slot="dropdown-menu-radio-item"
+	class={cn(
+		"focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm data-inset:pl-7 [&_svg:not([class*='size-'])]:size-4 relative flex cursor-default items-center outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		className
+	)}
+	{...restProps}
+>
+	{#snippet children({ checked })}
+		<span
+			class="absolute right-2 flex items-center justify-center pointer-events-none"
+			data-slot="dropdown-menu-radio-item-indicator"
+		>
+			{#if checked}
+				<CheckIcon  />
+			{/if}
+		</span>
+		{@render childrenProp?.({ checked })}
+	{/snippet}
+</DropdownMenuPrimitive.RadioItem>

--- a/apps/web/src/lib/components/ui/dropdown-menu/dropdown-menu-separator.svelte
+++ b/apps/web/src/lib/components/ui/dropdown-menu/dropdown-menu-separator.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { DropdownMenu as DropdownMenuPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: DropdownMenuPrimitive.SeparatorProps = $props();
+</script>
+
+<DropdownMenuPrimitive.Separator
+	bind:ref
+	data-slot="dropdown-menu-separator"
+	class={cn("bg-border -mx-1 my-1 h-px", className)}
+	{...restProps}
+/>

--- a/apps/web/src/lib/components/ui/dropdown-menu/dropdown-menu-shortcut.svelte
+++ b/apps/web/src/lib/components/ui/dropdown-menu/dropdown-menu-shortcut.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn, type WithElementRef } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLSpanElement>> = $props();
+</script>
+
+<span
+	bind:this={ref}
+	data-slot="dropdown-menu-shortcut"
+	class={cn("text-muted-foreground group-focus/dropdown-menu-item:text-accent-foreground ml-auto text-xs tracking-widest", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</span>

--- a/apps/web/src/lib/components/ui/dropdown-menu/dropdown-menu-sub-content.svelte
+++ b/apps/web/src/lib/components/ui/dropdown-menu/dropdown-menu-sub-content.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { DropdownMenu as DropdownMenuPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: DropdownMenuPrimitive.SubContentProps = $props();
+</script>
+
+<DropdownMenuPrimitive.SubContent
+	bind:ref
+	data-slot="dropdown-menu-sub-content"
+	class={cn("data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 bg-popover text-popover-foreground min-w-[96px] rounded-lg p-1 shadow-lg ring-1 duration-100 w-auto", className)}
+	{...restProps}
+/>

--- a/apps/web/src/lib/components/ui/dropdown-menu/dropdown-menu-sub-trigger.svelte
+++ b/apps/web/src/lib/components/ui/dropdown-menu/dropdown-menu-sub-trigger.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+	import { DropdownMenu as DropdownMenuPrimitive } from "bits-ui";
+	import ChevronRightIcon from '@lucide/svelte/icons/chevron-right';
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		inset,
+		children,
+		...restProps
+	}: DropdownMenuPrimitive.SubTriggerProps & {
+		inset?: boolean;
+	} = $props();
+</script>
+
+<DropdownMenuPrimitive.SubTrigger
+	bind:ref
+	data-slot="dropdown-menu-sub-trigger"
+	data-inset={inset}
+	class={cn(
+		"focus:bg-accent focus:text-accent-foreground data-open:bg-accent data-open:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground gap-1.5 rounded-md px-1.5 py-1 text-sm data-inset:pl-7 [&_svg:not([class*='size-'])]:size-4 flex cursor-default items-center outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		className
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+	<ChevronRightIcon class="ml-auto" />
+</DropdownMenuPrimitive.SubTrigger>

--- a/apps/web/src/lib/components/ui/dropdown-menu/dropdown-menu-sub.svelte
+++ b/apps/web/src/lib/components/ui/dropdown-menu/dropdown-menu-sub.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { DropdownMenu as DropdownMenuPrimitive } from "bits-ui";
+
+	let { open = $bindable(false), ...restProps }: DropdownMenuPrimitive.SubProps = $props();
+</script>
+
+<DropdownMenuPrimitive.Sub bind:open {...restProps} />

--- a/apps/web/src/lib/components/ui/dropdown-menu/dropdown-menu-trigger.svelte
+++ b/apps/web/src/lib/components/ui/dropdown-menu/dropdown-menu-trigger.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { DropdownMenu as DropdownMenuPrimitive } from "bits-ui";
+
+	let { ref = $bindable(null), ...restProps }: DropdownMenuPrimitive.TriggerProps = $props();
+</script>
+
+<DropdownMenuPrimitive.Trigger bind:ref data-slot="dropdown-menu-trigger" {...restProps} />

--- a/apps/web/src/lib/components/ui/dropdown-menu/dropdown-menu.svelte
+++ b/apps/web/src/lib/components/ui/dropdown-menu/dropdown-menu.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { DropdownMenu as DropdownMenuPrimitive } from "bits-ui";
+
+	let { open = $bindable(false), ...restProps }: DropdownMenuPrimitive.RootProps = $props();
+</script>
+
+<DropdownMenuPrimitive.Root bind:open {...restProps} />

--- a/apps/web/src/lib/components/ui/dropdown-menu/index.ts
+++ b/apps/web/src/lib/components/ui/dropdown-menu/index.ts
@@ -1,0 +1,54 @@
+import Root from "./dropdown-menu.svelte";
+import Sub from "./dropdown-menu-sub.svelte";
+import CheckboxGroup from "./dropdown-menu-checkbox-group.svelte";
+import CheckboxItem from "./dropdown-menu-checkbox-item.svelte";
+import Content from "./dropdown-menu-content.svelte";
+import Group from "./dropdown-menu-group.svelte";
+import Item from "./dropdown-menu-item.svelte";
+import Label from "./dropdown-menu-label.svelte";
+import RadioGroup from "./dropdown-menu-radio-group.svelte";
+import RadioItem from "./dropdown-menu-radio-item.svelte";
+import Separator from "./dropdown-menu-separator.svelte";
+import Shortcut from "./dropdown-menu-shortcut.svelte";
+import Trigger from "./dropdown-menu-trigger.svelte";
+import SubContent from "./dropdown-menu-sub-content.svelte";
+import SubTrigger from "./dropdown-menu-sub-trigger.svelte";
+import GroupHeading from "./dropdown-menu-group-heading.svelte";
+import Portal from "./dropdown-menu-portal.svelte";
+
+export {
+	CheckboxGroup,
+	CheckboxItem,
+	Content,
+	Portal,
+	Root as DropdownMenu,
+	CheckboxGroup as DropdownMenuCheckboxGroup,
+	CheckboxItem as DropdownMenuCheckboxItem,
+	Content as DropdownMenuContent,
+	Portal as DropdownMenuPortal,
+	Group as DropdownMenuGroup,
+	Item as DropdownMenuItem,
+	Label as DropdownMenuLabel,
+	RadioGroup as DropdownMenuRadioGroup,
+	RadioItem as DropdownMenuRadioItem,
+	Separator as DropdownMenuSeparator,
+	Shortcut as DropdownMenuShortcut,
+	Sub as DropdownMenuSub,
+	SubContent as DropdownMenuSubContent,
+	SubTrigger as DropdownMenuSubTrigger,
+	Trigger as DropdownMenuTrigger,
+	GroupHeading as DropdownMenuGroupHeading,
+	Group,
+	GroupHeading,
+	Item,
+	Label,
+	RadioGroup,
+	RadioItem,
+	Root,
+	Separator,
+	Shortcut,
+	Sub,
+	SubContent,
+	SubTrigger,
+	Trigger,
+};


### PR DESCRIPTION
So far into development, the app relied on using the browser provided `alert()` api. This led the popup to look out of place since the UI of `alert()` doesn't match the one defined in the application. This change adds a custom alert that can be customized to act as both an information alert and confirmation alert.