### PR TITLE
fix: QOE Improvements

### DIFF
--- a/apps/web/src/lib/brain/store.svelte.ts
+++ b/apps/web/src/lib/brain/store.svelte.ts
@@ -469,13 +469,16 @@ class Project {
         // Let the engine clear its own inner state mechanisms safely
         this.engine.newProject();
 
+        //Get the old machine type
+        const mType: EngineTypes = this.project_details.type;
+
         // Reset project details
         this.project_details = {
             ...this.project_details,
             name: `FSM_Project_${date.toDateString()}`,
             author: "Unnamed Author",
             created: date.toDateString(),
-            type: EngineTypes.FREE,
+            type: mType,
         };
 
         // Make sure engine name matches the reset name

--- a/apps/web/src/lib/components/generic/Window.svelte
+++ b/apps/web/src/lib/components/generic/Window.svelte
@@ -58,7 +58,7 @@
         style:--top-pos={`${y}px`}
         style:--width-val={`${width}px`}
         style:--height-val={`${height}px`}
-        class="absolute flex flex-col z-100 p-2 bg-card border border-border rounded-md overflow-scroll shadow-[0px_0px_50px_0px_#00000085]">
+        class="absolute flex flex-col z-10 p-2 bg-card border border-border rounded-md overflow-scroll shadow-[0px_0px_50px_0px_#00000085]">
         <span class="flex justify-center items-center px-3 mb-3">
             <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
             <p

--- a/apps/web/src/lib/components/popus/NodeCustomizer.svelte
+++ b/apps/web/src/lib/components/popus/NodeCustomizer.svelte
@@ -61,8 +61,12 @@
                     isEnd: false,
                 } as State);
 
+                // Set New State Types
                 if (newIsStart) ProjectClass.engine.setStart(currentId);
                 if (newIsEnd) ProjectClass.engine.setEnd(currentId);
+                if (!newIsStart && !newIsEnd) {
+                    ProjectClass.engine.setIntermediate(currentId);
+                }
             }
 
             if (color?.length === 7) {

--- a/apps/web/src/lib/components/popus/StringValidator.svelte
+++ b/apps/web/src/lib/components/popus/StringValidator.svelte
@@ -39,6 +39,9 @@
 
     /** Valid the string entered */
     function validateString() {
+        // Clear out any result from previous run
+        show_result = { show: false, result: null };
+
         if ("validateString" in ProjectClass.engine) {
             try {
                 console.log(ProjectClass.engine.languageAlphabet);

--- a/packages/engine/DFA.ts
+++ b/packages/engine/DFA.ts
@@ -23,6 +23,15 @@ export class DFA extends FSMEngine {
     }
 
     /**
+     * Set a state as intermediate state
+     * @param id Reference id of start state
+     */
+    override setIntermediate(id: number): void {
+        super.setIntermediate(id);
+        this.startState = undefined;
+    }
+
+    /**
      * Add new alphabets to the language grammar
      * @param alphs one or more language alphabets passed as arguments (not as list)
      */
@@ -234,6 +243,18 @@ export class DFA extends FSMEngine {
 
     }
 
+
+    /**
+     * Create a new Project
+     */
+    override newProject(): void {
+        super.newProject(); // This already clears nodes and transitions
+
+        // Clear the startState and alphabet set as well
+        this.languageAlphabet.clear();
+        this.startState = undefined;
+    }
+
     /********* HELPER FUNCTIONS *********/
     private verifyAlphExistance(alph: string) {
         if (!this.languageAlphabet.has(alph)) {
@@ -245,6 +266,9 @@ export class DFA extends FSMEngine {
 
     private verifyStartState() {
         if (this.startState === undefined) {
+            throw new Error(`Start State Does not exist`);
+        } else if (!this.getState(this.startState).isStart) {
+            this.startState = undefined;
             throw new Error(`Start State Does not exist`);
         }
     }

--- a/packages/engine/FSMEngine.ts
+++ b/packages/engine/FSMEngine.ts
@@ -234,6 +234,18 @@ export class FSMEngine {
     }
 
     /**
+     * Mark the provided state as INTERMEDIATE.
+     * Basically remove it as start and/or end
+     * @param id Reference id of the State
+     */
+    setIntermediate(id: number) {
+        this.verifyStateExistance(id);
+
+        this.nodes.get(id)!.isEnd = false;
+        this.nodes.get(id)!.isStart = false;
+    }
+
+    /**
      * Adds a new Transition.
      * In Case you are wondering, a reference number of the state
      * is returned when a new state is added @see addState method


### PR DESCRIPTION
- Creating a new project accidentally always set engine type to FREE, which has now been fixed.
- Setting a state as Start worked fine, but setting an already existing start state to intermediate did not properly unmark it in DFA engine source. This has now been fixed by adding a setIntermediate method.
- The popup window had a higher z value (z-100) than the alerts and settings popups (z-20). This made the Window appear ontop of open alerts. This has also been fixed in this update.